### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/src/util/AESCrypto.java
+++ b/src/util/AESCrypto.java
@@ -5,7 +5,7 @@ import org.json.JSONObject;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -14,8 +14,8 @@ import java.util.Base64;
 
 public class AESCrypto {
 
-    private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
-    private static final int IV_LENGTH = 16;
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int IV_LENGTH = 12; // GCM recommends 12 bytes
     private static final int KEY_LENGTH = 32;
 
     private static byte[] prepareKey(String key) throws NoSuchAlgorithmException {
@@ -33,9 +33,9 @@ public class AESCrypto {
 
         Cipher cipher = Cipher.getInstance(ALGORITHM);
         SecretKeySpec secretKey = new SecretKeySpec(keyBuffer, "AES");
-        IvParameterSpec ivParams = new IvParameterSpec(iv);
+        GCMParameterSpec gcmParams = new GCMParameterSpec(128, iv); // 128-bit tag
 
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivParams);
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmParams);
 
         byte[] encrypted = cipher.doFinal(data.getBytes("UTF-8"));
 
@@ -48,9 +48,9 @@ public class AESCrypto {
 
         Cipher cipher = Cipher.getInstance(ALGORITHM);
         SecretKeySpec secretKey = new SecretKeySpec(keyBuffer, "AES");
-        IvParameterSpec ivParams = new IvParameterSpec(iv);
+        GCMParameterSpec gcmParams = new GCMParameterSpec(128, iv);
 
-        cipher.init(Cipher.DECRYPT_MODE, secretKey, ivParams);
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmParams);
 
         byte[] decrypted = cipher.doFinal(Base64.getDecoder().decode(encryptedData.getContent()));
         return new String(decrypted, "UTF-8");


### PR DESCRIPTION
Potential fix for [https://github.com/wrappedcbdc/cngn-java-library/security/code-scanning/1](https://github.com/wrappedcbdc/cngn-java-library/security/code-scanning/1)

The most robust way to fix this issue is to replace the use of `"AES/CBC/PKCS5Padding"` with `"AES/GCM/NoPadding"`. This ensures that encryption is both *confidential* (like CBC mode) and *authenticated* (unlike bare CBC), thereby eliminating the risk of padding oracle attacks. This change will require:
- Updating the `ALGORITHM` constant.
- Changing decryption/encryption code to use GCM-specific constructs: use `GCMParameterSpec` instead of `IvParameterSpec`, and set an authentication tag size (typically 128 bits).
- IV generation needs to remain 12 bytes (96 bits) for GCM per NIST recommendations rather than 16 bytes; adjust IV length accordingly.
- The structure of the return/result `AESEncryptionResponse` can remain, but tag and ciphertext extraction will need to match GCM (no additional steps needed; Java's GCM handles this under the hood).
- Imports: add `javax.crypto.spec.GCMParameterSpec`.

All necessary changes are strictly limited to your code region: change the algorithm string; change IV length and parameter use; add one import.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
